### PR TITLE
Upgrade to working version 40006-alpha

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ MAINTAINER pizycki
 # Port Raven Studio will be hosted
 EXPOSE 8080
 
-ADD http://hibernatingrhinos.com/downloads/ravendb%20for%20ubuntu%2016.04%20x64/40004-alpha /home/Raven.tar.bz2
+ADD http://hibernatingrhinos.com/downloads/ravendb%20for%20ubuntu%2016.04%20x64/40006-alpha /home/Raven.tar.bz2
 
 # Prepare container and Extract RavenDB files to directory
 RUN apt-get update \


### PR DESCRIPTION
This is a confirmed compatible version of RavenDB running in this image.<br /><br />Setup: <br />Win 10 Enterprise<br />Docker for windows 1.12.6 (9655)<br />Running Version:<br />RavenDB Server: 4.0.0-alpha-40006<br />RavenDB Studio: 4.0.0-alpha-40006